### PR TITLE
feat: add online IDE support

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,8 @@ Web Site: [Code Time](https://codetime.datreks.com)
 3. In VSCode, Press <kbd>F1</kbd>, enter `token` to find the command: `CodeTime: Enter Token`, Press <kbd>Enter</kbd> and then input your token.
 4. Write some code, visit the dashboard and check if data is available.
 
+> If using an online IDE like [GitHub Codespaces](https://docs.github.com/en/codespaces), add your token to global ENV variable `CODETIME_TOKEN`.
+
 ## Settings
 
 ### Status Bar Info

--- a/src/codetime.ts
+++ b/src/codetime.ts
@@ -70,8 +70,9 @@ export class CodeTime {
   }
 
   initSetToken() {
-    let token: string | undefined = this.state.get("token");
-    this.token = token ? token : "";
+    const stateToken = this.state.get<string>('token');
+    const envToken = process.env.CODETIME_TOKEN;
+    this.token = envToken ? envToken : stateToken ? stateToken : "";
     if (this.token === "") {
       this.setToken();
     }


### PR DESCRIPTION
Similar with https://github.com/wakatime/vscode-wakatime/pull/220

In online IDE like [GitHub Codespaces](https://docs.github.com/en/codespaces), you can pass secret env variable to the online container. And then codetime extension will automatically use this env variable to init token.