### PR TITLE
feat: add proxy support for API requests

### DIFF
--- a/package.json
+++ b/package.json
@@ -68,6 +68,11 @@
           "default": "https://api.codetime.dev",
           "description": "%config.serverEntrypoint.description%"
         },
+        "codetime.proxy": {
+          "type": "string",
+          "default": "",
+          "description": "%config.proxy.description%"
+        },
         "codetime.displayLanguage.title": {
           "type": "string",
           "default": "Auto",

--- a/package.json
+++ b/package.json
@@ -133,7 +133,6 @@
     "@vscode/l10n": "^0.0.18",
     "@vscode/test-electron": "^2.5.2",
     "date-fns": "^4.1.0",
-    "got": "14.4.7",
     "os-name": "^6.1.0",
     "uuid": "^11.1.0"
   },
@@ -141,7 +140,6 @@
     "@jannchie/eslint-config": "^3.6.1",
     "@types/date-fns": "^2.6.3",
     "@types/glob": "^9.0.0",
-    "@types/got": "^9.6.12",
     "@types/mocha": "^10.0.10",
     "@types/node": "^24.0.15",
     "@types/vscode": "^1.99.0",

--- a/package.nls.json
+++ b/package.nls.json
@@ -10,6 +10,7 @@
   "config.statusBarInfo.enum.today": "Show today code time",
   "config.statusBarInfo.enum.24h": "Show 24h code time",
   "config.serverEntrypoint.description": "Server entrypoint defines the URL for reporting data to a server.",
+  "config.proxy.description": "Proxy URL for API requests, e.g. http://127.0.0.1:8080. Leave empty to use system proxy environment variables (HTTP_PROXY/HTTPS_PROXY).",
   "codetime.displayLanguage.title": "Display Language",
   "codetime.displayLanguage.description": "Select the display language for the CodeTime extension.",
   "codetime.displayLanguage.enum.zh-cn": "Chinese (Simplified)",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -23,9 +23,6 @@ importers:
       date-fns:
         specifier: ^4.1.0
         version: 4.1.0
-      got:
-        specifier: 14.4.7
-        version: 14.4.7
       os-name:
         specifier: ^6.1.0
         version: 6.1.0
@@ -42,9 +39,6 @@ importers:
       '@types/glob':
         specifier: ^9.0.0
         version: 9.0.0
-      '@types/got':
-        specifier: ^9.6.12
-        version: 9.6.12
       '@types/mocha':
         specifier: ^10.0.10
         version: 10.0.10
@@ -401,9 +395,6 @@ packages:
     resolution: {integrity: sha512-QNqXyfVS2wm9hweSYD2O7F0G06uurj9kZ96TRQE5Y9hU7+tgdZwIkbAKc5Ocy1HxEY2kuDQa6cQ1WRs/O5LFKA==}
     engines: {node: ^12.20.0 || ^14.18.0 || >=16.0.0}
 
-  '@sec-ant/readable-stream@0.4.1':
-    resolution: {integrity: sha512-831qok9r2t8AlxLko40y2ebgSDhenenCatLVeW/uBtnHPyhHOvG0C7TvfgecV+wHzIm5KUICgzmVpWS+IMEAeg==}
-
   '@secretlint/config-creator@10.2.1':
     resolution: {integrity: sha512-nyuRy8uo2+mXPIRLJ93wizD1HbcdDIsVfgCT01p/zGVFrtvmiL7wqsl4KgZH0QFBM/KRLDLeog3/eaM5ASjtvw==}
     engines: {node: '>=20.0.0'}
@@ -449,10 +440,6 @@ packages:
     resolution: {integrity: sha512-F5k1qpoMoUe7rrZossOBgJ3jWKv/FGDBZIwepqnefgPmNienBdInxhtZeXiGwjcxXHVhsdgp6I5Fi/M8PMgwcw==}
     engines: {node: '>=20.0.0'}
 
-  '@sindresorhus/is@7.0.2':
-    resolution: {integrity: sha512-d9xRovfKNz1SKieM0qJdO+PQonjnnIfSNWfHYnBSJ9hkjm0ZPw6HlxscDXYstp3z+7V2GOFHc+J0CYrYTjqCJw==}
-    engines: {node: '>=18'}
-
   '@sindresorhus/merge-streams@2.3.0':
     resolution: {integrity: sha512-LtoMMhxAlorcGhmFYI+LhPgbPZCkgP6ra1YL604EeF6U98pLlQ3iWIGMdWSC+vWmPBWBNgmDBAhnAobLROJmwg==}
     engines: {node: '>=18'}
@@ -462,10 +449,6 @@ packages:
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
     peerDependencies:
       eslint: '>=9.0.0'
-
-  '@szmarczak/http-timer@5.0.1':
-    resolution: {integrity: sha512-+PmQX0PiAYPMeVYe237LJAYvOMYW1j2rH5YROyS3b4CTVJum34HfRvKvAzozHAQG0TnHNdUfY9nCeUyRAs//cw==}
-    engines: {node: '>=14.16'}
 
   '@textlint/ast-node-types@15.2.0':
     resolution: {integrity: sha512-nr9wEiZCNYafGZ++uWFZgPlDX3Bi7u4T2d5swpaoMvc1G2toXsBfe7UNVwXZq5dvYDbQN7vDeb3ltlKQ8JnPNQ==}
@@ -502,12 +485,6 @@ packages:
     resolution: {integrity: sha512-00UxlRaIUvYm4R4W9WYkN8/J+kV8fmOQ7okeH6YFtGWFMt3odD45tpG5yA5wnL7HE6lLgjaTW5n14ju2hl2NNA==}
     deprecated: This is a stub types definition. glob provides its own type definitions, so you do not need this installed.
 
-  '@types/got@9.6.12':
-    resolution: {integrity: sha512-X4pj/HGHbXVLqTpKjA2ahI4rV/nNBc9mGO2I/0CgAra+F2dKgMXnENv2SRpemScBzBAI4vMelIVYViQxlSE6xA==}
-
-  '@types/http-cache-semantics@4.0.4':
-    resolution: {integrity: sha512-1m0bIFVc7eJWyve9S0RnuRgcQqF/Xd5QsUZAZeQFr1Q3/p9JWoQQEqmVy+DPTNpGXwhgIetAoYF8JSc33q29QA==}
-
   '@types/json-schema@7.0.15':
     resolution: {integrity: sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==}
 
@@ -528,9 +505,6 @@ packages:
 
   '@types/sarif@2.1.7':
     resolution: {integrity: sha512-kRz0VEkJqWLf1LLVN4pT1cg1Z9wAuvI6L97V3m2f5B76Tg8d413ddvLBPTEHAZJlnn4XSvu0FkZtViCQGVyrXQ==}
-
-  '@types/tough-cookie@4.0.5':
-    resolution: {integrity: sha512-/Ad8+nIOV7Rl++6f1BdKxFSMgmoqEoYbHRpPcx3JEfv8VRsQe9Z4mCXeJBzxs7mbHY/XOZZuXlRNfhpVPbs6ZA==}
 
   '@types/unist@3.0.3':
     resolution: {integrity: sha512-ko/gIFJRv177XgZsZcBwnqJN5x/Gien8qNOn0D5bQU/zAzVf9Zt3BlcUiLqhV9y4ARk0GbT3tnUiPNgnTXzc/Q==}
@@ -915,14 +889,6 @@ packages:
     resolution: {integrity: sha512-b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ==}
     engines: {node: '>=8'}
 
-  cacheable-lookup@7.0.0:
-    resolution: {integrity: sha512-+qJyx4xiKra8mZrcwhjMRMUhD5NR1R8esPkzIYxX96JiecFoxAXFuz/GpR3+ev4PE1WamHip78wV0vcmPQtp8w==}
-    engines: {node: '>=14.16'}
-
-  cacheable-request@12.0.1:
-    resolution: {integrity: sha512-Yo9wGIQUaAfIbk+qY0X4cDQgCosecfBe3V9NSyeY4qPC2SAkbCS4Xj79VP8WOzitpJUZKc/wsRCYF5ariDIwkg==}
-    engines: {node: '>=18'}
-
   call-bind-apply-helpers@1.0.2:
     resolution: {integrity: sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==}
     engines: {node: '>= 0.4'}
@@ -1099,10 +1065,6 @@ packages:
   default-browser@5.2.1:
     resolution: {integrity: sha512-WY/3TUME0x3KPYdRRxEJJvXRHV4PyPoUsxtZa78lwItwRQRHhd2U9xOscaT/YTf8uCXIAjeJOFBVEh/7FtD8Xg==}
     engines: {node: '>=18'}
-
-  defer-to-connect@2.0.1:
-    resolution: {integrity: sha512-4tvttepXG1VaYGrRibk5EwJd1t4udunSOVMdLSAL6mId1ix438oPwPZMALY41FCijukO1L0twNcGsdzS7dHgDg==}
-    engines: {node: '>=10'}
 
   define-lazy-prop@3.0.0:
     resolution: {integrity: sha512-N+MeXYoqr3pOgn8xfyRPREN7gHakLYjhsHhWGT3fWAiL4IkAt0iDw14QiiEm2bE30c5XX5q0FtAA3CK5f9/BUg==}
@@ -1522,14 +1484,6 @@ packages:
     resolution: {integrity: sha512-gIXjKqtFuWEgzFRJA9WCQeSJLZDjgJUOMCMzxtvFq/37KojM1BFGufqsCy0r4qSQmYLsZYMeyRqzIWOMup03sw==}
     engines: {node: '>=14'}
 
-  form-data-encoder@4.1.0:
-    resolution: {integrity: sha512-G6NsmEW15s0Uw9XnCg+33H3ViYRyiM0hMrMhhqQOR8NFc5GhYrI+6I3u7OTw7b91J2g8rtvMBZJDbcGb2YUniw==}
-    engines: {node: '>= 18'}
-
-  form-data@2.5.5:
-    resolution: {integrity: sha512-jqdObeR2rxZZbPSGL+3VckHMYtu+f9//KXBsVny6JSX/pa38Fy+bGjuG8eW/H6USNQWhLi8Num++cU2yOCNz4A==}
-    engines: {node: '>= 0.12'}
-
   form-data@4.0.4:
     resolution: {integrity: sha512-KrGhL9Q4zjj0kiUt5OO4Mr/A/jlI2jDYs5eHBpYHPcBEVSiipAvn2Ko2HnPe20rmcuuvMHNdZFp+4IlGTMF0Ow==}
     engines: {node: '>= 6'}
@@ -1572,10 +1526,6 @@ packages:
     resolution: {integrity: sha512-VaUJspBffn/LMCJVoMvSAdmscJyS1auj5Zulnn5UoYcY531UWmdwhRWkcGKnGU93m5HSXP9LP2usOryrBtQowA==}
     engines: {node: '>=16'}
 
-  get-stream@9.0.1:
-    resolution: {integrity: sha512-kVCxPF3vQM/N0B1PmoqVUqgHP+EeVjmZSQn+1oCRPxd2P21P2F19lIgbR3HBosbB1PUhOAoctJnfEn2GbN2eZA==}
-    engines: {node: '>=18'}
-
   get-tsconfig@4.10.1:
     resolution: {integrity: sha512-auHyJ4AgMz7vgS8Hp3N6HXSmlMdUyhSUrfBF16w153rxtLIEOE+HGqaBppczZvnHLqQJfiHotCYpNhl0lUROFQ==}
 
@@ -1598,11 +1548,13 @@ packages:
 
   glob@10.4.5:
     resolution: {integrity: sha512-7Bv8RF0k6xjo7d4A/PxYLbUCfb6c+Vpd2/mB2yRDlew7Jb5hEXiCD9ibfO7wpk8i4sevK6DFny9h7EYbM3/sHg==}
+    deprecated: Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me
     hasBin: true
 
   glob@11.0.3:
     resolution: {integrity: sha512-2Nim7dha1KVkaiF4q6Dj+ngPPMdfvLJEOpZk/jKiUAkqKebpGAWQXAq9z1xu9HKu5lWfqw/FASuccEjyznjPaA==}
     engines: {node: 20 || >=22}
+    deprecated: Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me
     hasBin: true
 
   globals@14.0.0:
@@ -1624,10 +1576,6 @@ packages:
   gopd@1.2.0:
     resolution: {integrity: sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==}
     engines: {node: '>= 0.4'}
-
-  got@14.4.7:
-    resolution: {integrity: sha512-DI8zV1231tqiGzOiOzQWDhsBmncFW7oQDH6Zgy6pDPrqJuVZMtoSgPLLsBZQj8Jg4JFfwoOsDA8NGtLQLnIx2g==}
-    engines: {node: '>=20'}
 
   graceful-fs@4.2.11:
     resolution: {integrity: sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==}
@@ -1666,16 +1614,9 @@ packages:
   htmlparser2@10.0.0:
     resolution: {integrity: sha512-TwAZM+zE5Tq3lrEHvOlvwgj1XLWQCtaaibSN11Q+gGBAS7Y1uZSWwXXRe4iF6OXnaq1riyQAPFOBtYc77Mxq0g==}
 
-  http-cache-semantics@4.2.0:
-    resolution: {integrity: sha512-dTxcvPXqPvXBQpq5dUr6mEMJX4oIEFv6bwom3FDwKRDsuIjjJGANqhBuoAn9c1RQJIdAKav33ED65E2ys+87QQ==}
-
   http-proxy-agent@7.0.2:
     resolution: {integrity: sha512-T1gkAiYYDWYx3V5Bmyu7HcfcvL7mUrTWiM6yOfa3PIphViJ/gFPbvidQ+veqSOHci/PxBcDabeUNCzpOODJZig==}
     engines: {node: '>= 14'}
-
-  http2-wrapper@2.2.1:
-    resolution: {integrity: sha512-V5nVw1PAOgfI3Lmeaj2Exmeg7fenjhRUgz1lPSezy1CuhPYbgQtbQj4jZfEAEMlaL+vupsvhjqCyjzob0yxsmQ==}
-    engines: {node: '>=10.19.0'}
 
   https-proxy-agent@7.0.6:
     resolution: {integrity: sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==}
@@ -1783,10 +1724,6 @@ packages:
   is-stream@3.0.0:
     resolution: {integrity: sha512-LnQR4bZ9IADDRSkvpqMGvt/tEJWclzklNgSw48V5EAaAeDd6qGvN8ei6k5p0tvxSR171VmGyHuTiAOfxAbr8kA==}
     engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
-
-  is-stream@4.0.1:
-    resolution: {integrity: sha512-Dnz92NInDqYckGEUJv689RbRiTSEHCQ7wOVeALbkOz999YpqT46yMRIGtSNl2iCL1waAZSx40+h59NV/EwzV/A==}
-    engines: {node: '>=18'}
 
   is-unicode-supported@0.1.0:
     resolution: {integrity: sha512-knxG2q4UC3u8stRGyAVJCOdxFmv5DZiRcdlIaAQXAbSfJya+OhopNotLQrstBhququ4ZpuKbDc/8S6mgXgPFPw==}
@@ -1977,10 +1914,6 @@ packages:
 
   longest-streak@3.1.0:
     resolution: {integrity: sha512-9Ri+o0JYgehTaVBBDoMqIl8GXtbWg711O3srftcHhZ0dqnETqLaoIK0x17fUw9rFSlK/0NlsKe0Ahhyl5pXE2g==}
-
-  lowercase-keys@3.0.0:
-    resolution: {integrity: sha512-ozCC6gdQ+glXOQsveKD0YsDy8DSQFjDTz4zyzEHNV5+JP5D62LmfDZ6o1cycFx9ouG940M5dE8C8CTewdj2YWQ==}
-    engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
 
   lru-cache@10.4.3:
     resolution: {integrity: sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==}
@@ -2173,10 +2106,6 @@ packages:
     resolution: {integrity: sha512-z0yWI+4FDrrweS8Zmt4Ej5HdJmky15+L2e6Wgn3+iK5fWzb6T3fhNFq2+MeTRb064c6Wr4N/wv0DzQTjNzHNGQ==}
     engines: {node: '>=10'}
 
-  mimic-response@4.0.0:
-    resolution: {integrity: sha512-e5ISH9xMYU0DzrT+jl8q2ze9D6eWBto+I8CNpe+VI+K2J/F/k3PdkdTdz4wvGVH4NTpo+NRYTVIuMQEMMcsLqg==}
-    engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
-
   min-indent@1.0.1:
     resolution: {integrity: sha512-I9jwMn07Sy/IwOj3zVkVik2JTvgpaykDZEigL6Rx6N9LbMywwUSMtxET+7lVoDLLd3O3IXwJwvuuns8UB/HeAg==}
     engines: {node: '>=4'}
@@ -2259,10 +2188,6 @@ packages:
     resolution: {integrity: sha512-V6gygoYb/5EmNI+MEGrWkC+e6+Rr7mTmfHrxDbLzxQogBkgzo76rkok0Am6thgSF7Mv2nLOajAJj5vDJZEFn7g==}
     engines: {node: ^16.14.0 || >=18.0.0}
 
-  normalize-url@8.0.2:
-    resolution: {integrity: sha512-Ee/R3SyN4BuynXcnTaekmaVdbDAEiNrHqjQIA37mHU8G9pf7aaAD4ZX3XjBLo6rsdcxA/gtkcNYZLt30ACgynw==}
-    engines: {node: '>=14.16'}
-
   npm-run-path@5.3.0:
     resolution: {integrity: sha512-ppwTtiJZq0O/ai0z7yfudtBpWIoxM8yE6nHi1X47eFR2EWORqfbu6CnPlNsjeN683eT0qG6H/Pyf9fCcvjnnnQ==}
     engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
@@ -2300,10 +2225,6 @@ packages:
   os-name@6.1.0:
     resolution: {integrity: sha512-zBd1G8HkewNd2A8oQ8c6BN/f/c9EId7rSUueOLGu28govmUctXmM+3765GwsByv9nYUdrLqHphXlYIc86saYsg==}
     engines: {node: '>=18'}
-
-  p-cancelable@4.0.1:
-    resolution: {integrity: sha512-wBowNApzd45EIKdO1LaU+LrMBwAcjfPaYtVzV3lmfM3gf8Z4CHZsiIqlM8TZZ8okYvh5A1cP6gTfCRQtwUpaUg==}
-    engines: {node: '>=14.16'}
 
   p-limit@2.3.0:
     resolution: {integrity: sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==}
@@ -2443,6 +2364,7 @@ packages:
   prebuild-install@7.1.3:
     resolution: {integrity: sha512-8Mf2cbV7x1cXPUILADGI3wuhfqWvtiLA1iclTDbFRZkgRQS0NqsPZphna9V+HyTEadheuPmjaJMsbzKQFOzLug==}
     engines: {node: '>=10'}
+    deprecated: No longer maintained. Please contact the author of the relevant native addon; alternatives are available.
     hasBin: true
 
   prelude-ls@1.2.1:
@@ -2476,10 +2398,6 @@ packages:
 
   queue-microtask@1.2.3:
     resolution: {integrity: sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==}
-
-  quick-lru@5.1.1:
-    resolution: {integrity: sha512-WuyALRjWPDGtt/wzJiadO5AXY+8hZ80hVpe6MyivgraREW751X3SbhRvG3eLKOYN+8VEvqLcf3wdnt44Z4S4SA==}
-    engines: {node: '>=10'}
 
   randombytes@2.1.0:
     resolution: {integrity: sha512-vYl3iOX+4CKUWuxGi9Ukhie6fsqXqS9FE2Zaic4tNFD2N2QQaXOMFbuKK4QmDHC0JO6B1Zp41J0LpT0oR68amQ==}
@@ -2538,9 +2456,6 @@ packages:
     resolution: {integrity: sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==}
     engines: {node: '>=0.10.0'}
 
-  resolve-alpn@1.2.1:
-    resolution: {integrity: sha512-0a1F4l73/ZFZOakJnQ3FvkJ2+gSTQWz/r2KE5OdDY0TxPm5h4GkqkWWfM47T7HsbnOtcJVEF4epCVy6u7Q3K+g==}
-
   resolve-cwd@3.0.0:
     resolution: {integrity: sha512-OrZaX2Mb+rJCpH/6CpSqt9xFVpN++x01XnN2ie9g6P5/3xelLAkXWVADpdz1IHD/KFfEXyE6V0U01OQ3UO2rEg==}
     engines: {node: '>=8'}
@@ -2560,10 +2475,6 @@ packages:
     resolution: {integrity: sha512-NPRy+/ncIMeDlTAsuqwKIiferiawhefFJtkNSW0qZJEqMEb+qBt/77B/jGeeek+F0uOeN05CDa6HXbbIgtVX4w==}
     engines: {node: '>= 0.4'}
     hasBin: true
-
-  responselike@3.0.0:
-    resolution: {integrity: sha512-40yHxbNcl2+rzXvZuVkrYohathsSJlMTXKryG5y8uciHv1+xDLHQpgjG64JUO9nrEq2jGLH6IZ8BcZyw3wrweg==}
-    engines: {node: '>=14.16'}
 
   restore-cursor@5.1.0:
     resolution: {integrity: sha512-oMA2dcrw6u0YfxJQXm342bFKX/E4sG9rbTzO9ptUcR/e8A33cHuvStiYOwH7fszkZlZ1z/ta9AAoPk2F4qIOHA==}
@@ -2947,6 +2858,7 @@ packages:
 
   uuid@8.3.2:
     resolution: {integrity: sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==}
+    deprecated: uuid@10 and below is no longer supported.  For ESM codebases, update to uuid@latest.  For CommonJS codebases, use uuid@11 (but be aware this version will likely be deprecated in 2028).
     hasBin: true
 
   validate-npm-package-license@3.0.4:
@@ -3004,6 +2916,7 @@ packages:
   whatwg-encoding@3.1.1:
     resolution: {integrity: sha512-6qN4hJdMwfYBtE3YBTTHhoeuUrDBPZmbQaxWAqSALV/MeEnR5z1xd8UKud2RAkFoPkmB+hli1TZSnyi84xz1vQ==}
     engines: {node: '>=18'}
+    deprecated: Use @exodus/bytes instead for a more spec-conformant and faster implementation
 
   whatwg-mimetype@4.0.0:
     resolution: {integrity: sha512-QaKxh0eNIi2mE9p2vEdzfagOKHCcj1pJ56EEHGQOVxp8r9/iszLUUV7v89x9O1p/T+NlTM5W7jW6+cz4Fq1YVg==}
@@ -3474,8 +3387,6 @@ snapshots:
 
   '@pkgr/core@0.2.9': {}
 
-  '@sec-ant/readable-stream@0.4.1': {}
-
   '@secretlint/config-creator@10.2.1':
     dependencies:
       '@secretlint/types': 10.2.1
@@ -3550,8 +3461,6 @@ snapshots:
 
   '@secretlint/types@10.2.1': {}
 
-  '@sindresorhus/is@7.0.2': {}
-
   '@sindresorhus/merge-streams@2.3.0': {}
 
   '@stylistic/eslint-plugin@5.2.0(eslint@9.31.0)':
@@ -3563,10 +3472,6 @@ snapshots:
       espree: 10.4.0
       estraverse: 5.3.0
       picomatch: 4.0.3
-
-  '@szmarczak/http-timer@5.0.1':
-    dependencies:
-      defer-to-connect: 2.0.1
 
   '@textlint/ast-node-types@15.2.0': {}
 
@@ -3621,14 +3526,6 @@ snapshots:
     dependencies:
       glob: 11.0.3
 
-  '@types/got@9.6.12':
-    dependencies:
-      '@types/node': 24.0.15
-      '@types/tough-cookie': 4.0.5
-      form-data: 2.5.5
-
-  '@types/http-cache-semantics@4.0.4': {}
-
   '@types/json-schema@7.0.15': {}
 
   '@types/mdast@4.0.4':
@@ -3646,8 +3543,6 @@ snapshots:
   '@types/normalize-package-data@2.4.4': {}
 
   '@types/sarif@2.1.7': {}
-
-  '@types/tough-cookie@4.0.5': {}
 
   '@types/unist@3.0.3': {}
 
@@ -4124,18 +4019,6 @@ snapshots:
 
   cac@6.7.14: {}
 
-  cacheable-lookup@7.0.0: {}
-
-  cacheable-request@12.0.1:
-    dependencies:
-      '@types/http-cache-semantics': 4.0.4
-      get-stream: 9.0.1
-      http-cache-semantics: 4.2.0
-      keyv: 4.5.4
-      mimic-response: 4.0.0
-      normalize-url: 8.0.2
-      responselike: 3.0.0
-
   call-bind-apply-helpers@1.0.2:
     dependencies:
       es-errors: 1.3.0
@@ -4286,6 +4169,7 @@ snapshots:
   decompress-response@6.0.0:
     dependencies:
       mimic-response: 3.1.0
+    optional: true
 
   deep-extend@0.6.0:
     optional: true
@@ -4300,8 +4184,6 @@ snapshots:
     dependencies:
       bundle-name: 4.1.0
       default-browser-id: 5.0.0
-
-  defer-to-connect@2.0.1: {}
 
   define-lazy-prop@3.0.0: {}
 
@@ -4776,17 +4658,6 @@ snapshots:
       cross-spawn: 7.0.6
       signal-exit: 4.1.0
 
-  form-data-encoder@4.1.0: {}
-
-  form-data@2.5.5:
-    dependencies:
-      asynckit: 0.4.0
-      combined-stream: 1.0.8
-      es-set-tostringtag: 2.1.0
-      hasown: 2.0.2
-      mime-types: 2.1.35
-      safe-buffer: 5.2.1
-
   form-data@4.0.4:
     dependencies:
       asynckit: 0.4.0
@@ -4833,11 +4704,6 @@ snapshots:
   get-stdin@7.0.0: {}
 
   get-stream@8.0.1: {}
-
-  get-stream@9.0.1:
-    dependencies:
-      '@sec-ant/readable-stream': 0.4.1
-      is-stream: 4.0.1
 
   get-tsconfig@4.10.1:
     dependencies:
@@ -4893,20 +4759,6 @@ snapshots:
 
   gopd@1.2.0: {}
 
-  got@14.4.7:
-    dependencies:
-      '@sindresorhus/is': 7.0.2
-      '@szmarczak/http-timer': 5.0.1
-      cacheable-lookup: 7.0.0
-      cacheable-request: 12.0.1
-      decompress-response: 6.0.0
-      form-data-encoder: 4.1.0
-      http2-wrapper: 2.2.1
-      lowercase-keys: 3.0.0
-      p-cancelable: 4.0.1
-      responselike: 3.0.0
-      type-fest: 4.41.0
-
   graceful-fs@4.2.11: {}
 
   graphemer@1.4.0: {}
@@ -4940,19 +4792,12 @@ snapshots:
       domutils: 3.2.2
       entities: 6.0.1
 
-  http-cache-semantics@4.2.0: {}
-
   http-proxy-agent@7.0.2:
     dependencies:
       agent-base: 7.1.4
       debug: 4.4.1(supports-color@8.1.1)
     transitivePeerDependencies:
       - supports-color
-
-  http2-wrapper@2.2.1:
-    dependencies:
-      quick-lru: 5.1.1
-      resolve-alpn: 1.2.1
 
   https-proxy-agent@7.0.6:
     dependencies:
@@ -5032,8 +4877,6 @@ snapshots:
       isobject: 3.0.1
 
   is-stream@3.0.0: {}
-
-  is-stream@4.0.1: {}
 
   is-unicode-supported@0.1.0: {}
 
@@ -5222,8 +5065,6 @@ snapshots:
       is-unicode-supported: 1.3.0
 
   longest-streak@3.1.0: {}
-
-  lowercase-keys@3.0.0: {}
 
   lru-cache@10.4.3: {}
 
@@ -5586,9 +5427,8 @@ snapshots:
 
   mimic-function@5.0.1: {}
 
-  mimic-response@3.1.0: {}
-
-  mimic-response@4.0.0: {}
+  mimic-response@3.1.0:
+    optional: true
 
   min-indent@1.0.1: {}
 
@@ -5687,8 +5527,6 @@ snapshots:
       semver: 7.7.2
       validate-npm-package-license: 3.0.4
 
-  normalize-url@8.0.2: {}
-
   npm-run-path@5.3.0:
     dependencies:
       path-key: 4.0.0
@@ -5744,8 +5582,6 @@ snapshots:
     dependencies:
       macos-release: 3.4.0
       windows-release: 6.1.0
-
-  p-cancelable@4.0.1: {}
 
   p-limit@2.3.0:
     dependencies:
@@ -5918,8 +5754,6 @@ snapshots:
 
   queue-microtask@1.2.3: {}
 
-  quick-lru@5.1.1: {}
-
   randombytes@2.1.0:
     dependencies:
       safe-buffer: 5.2.1
@@ -5995,8 +5829,6 @@ snapshots:
 
   require-from-string@2.0.2: {}
 
-  resolve-alpn@1.2.1: {}
-
   resolve-cwd@3.0.0:
     dependencies:
       resolve-from: 5.0.0
@@ -6012,10 +5844,6 @@ snapshots:
       is-core-module: 2.16.1
       path-parse: 1.0.7
       supports-preserve-symlinks-flag: 1.0.0
-
-  responselike@3.0.0:
-    dependencies:
-      lowercase-keys: 3.0.0
 
   restore-cursor@5.1.0:
     dependencies:

--- a/src/codetime.ts
+++ b/src/codetime.ts
@@ -85,7 +85,7 @@ export class CodeTime {
 
     return new Promise((resolve, reject) => {
       const startTime = Date.now()
-      this.out.appendLine(`[Req] ${method} ${path} proxy=${proxy || 'none'}`)
+      this.out.appendLine(`[Req] ${method} ${path} proxy=${proxy ? this.redactUrlForLogging(proxy) : 'none'}`)
 
       const finish = (parsed: { statusCode: number, body: string }) => {
         this.out.appendLine(`[Req] ${parsed.statusCode} after ${Date.now() - startTime}ms`)
@@ -159,9 +159,15 @@ export class CodeTime {
           payload || '',
         ]
         socket.write(lines.join('\r\n'))
+
+        const requestTimeout = setTimeout(() => {
+          socket.destroy(new Error('request timeout'))
+        }, 30_000)
+
         const chunks: Buffer[] = []
         socket.on('data', (chunk: Buffer) => chunks.push(chunk))
         socket.on('end', () => {
+          clearTimeout(requestTimeout)
           socket.destroy()
           try {
             finish(parseHttpResponse(Buffer.concat(chunks)))
@@ -172,6 +178,7 @@ export class CodeTime {
           }
         })
         socket.on('error', (e: any) => {
+          clearTimeout(requestTimeout)
           this.out.appendLine(`[Req] socket error: ${e.message}`)
           reject(e)
         })
@@ -180,7 +187,6 @@ export class CodeTime {
       const onProxyReady = (proxySocket: net.Socket | tls.TLSSocket) => {
         if (!isHttpsTarget) {
           this.out.appendLine(`[Req] proxy connected, sending HTTP request (absolute form)`)
-          proxySocket.setTimeout(0)
           writeRequestAndRead(
             proxySocket,
             `${method} ${url.toString()} HTTP/1.1`,
@@ -217,7 +223,6 @@ export class CodeTime {
             reject(new Error(`Proxy CONNECT failed: ${statusLine}`))
             return
           }
-          proxySocket.setTimeout(0)
           const residue = connectBuf.slice(idx + 4)
           if (residue.length > 0) {
             proxySocket.unshift(residue)

--- a/src/codetime.ts
+++ b/src/codetime.ts
@@ -1,6 +1,9 @@
 import * as os from 'node:os'
 import process from 'node:process'
-import got from 'got'
+import http from 'node:http'
+import https from 'node:https'
+import net from 'node:net'
+import tls from 'node:tls'
 
 import osName from 'os-name'
 import * as vscode from 'vscode'
@@ -43,15 +46,143 @@ export class CodeTime {
 
   public disposable!: vscode.Disposable
   state: vscode.Memento
-  client!: any
+  private proxyUrl: string = ''
   token: string = ''
   inter!: NodeJS.Timeout
   constructor(state: vscode.Memento, secrets: vscode.SecretStorage) {
     this.state = state
     this.secrets = secrets
     this.initSetToken().then(() => {
-      this.client = got
+      const configProxy = vscode.workspace.getConfiguration('codetime').get<string>('proxy')
+      this.proxyUrl = configProxy
+        || process.env.HTTPS_PROXY || process.env.HTTP_PROXY
+        || process.env.https_proxy || process.env.http_proxy
+        || ''
       this.init()
+    })
+  }
+
+  private apiRequest(method: string, path: string, body?: any): Promise<any> {
+    const serverUrl = vscode.workspace.getConfiguration('codetime').serverEntrypoint as string
+    const url = new URL(path, serverUrl)
+    const payload = body ? JSON.stringify(body) : undefined
+    const proxy = this.proxyUrl
+
+    return new Promise((resolve, reject) => {
+      const startTime = Date.now()
+      this.out.appendLine(`[Req] ${method} ${path} proxy=${proxy || 'none'}`)
+
+      const doRequest = (tlsSocket?: tls.TLSSocket) => {
+        if (tlsSocket) {
+          const lines = [
+            `${method} ${url.pathname + url.search} HTTP/1.1`,
+            `Host: ${url.hostname}`,
+            `User-Agent: CodeTime Client`,
+            `Authorization: Bearer ${this.token}`,
+            `Connection: close`,
+            ...(payload ? [`Content-Type: application/json`, `Content-Length: ${Buffer.byteLength(payload)}`] : []),
+            ``,
+            payload || ``,
+          ]
+          tlsSocket.write(lines.join('\r\n'))
+          let raw = ''
+          tlsSocket.on('data', (chunk: Buffer) => { raw += chunk.toString() })
+          tlsSocket.on('end', () => {
+            tlsSocket.destroy()
+            const headerEnd = raw.indexOf('\r\n\r\n')
+            const statusLine = raw.split('\r\n')[0]
+            const statusCode = Number(statusLine.split(' ')[1])
+            const body = headerEnd >= 0 ? raw.slice(headerEnd + 4) : ''
+            this.out.appendLine(`[Req] ${statusCode} after ${Date.now() - startTime}ms`)
+            if (statusCode === 401) {
+              reject({ response: { statusCode: 401 } })
+            }
+            else {
+              resolve({ body, statusCode })
+            }
+          })
+          tlsSocket.on('error', (e: any) => {
+            this.out.appendLine(`[Req] socket error: ${e.message}`)
+            reject(e)
+          })
+          return
+        }
+
+        const req = https.request({
+          method,
+          hostname: url.hostname,
+          port: 443,
+          path: url.pathname + url.search,
+          timeout: 30000,
+          headers: {
+            'User-Agent': 'CodeTime Client',
+            'Authorization': `Bearer ${this.token}`,
+            ...(payload ? { 'Content-Type': 'application/json', 'Content-Length': Buffer.byteLength(payload).toString() } : {}),
+          },
+        }, handleResponse)
+        req.on('error', (e: any) => {
+          this.out.appendLine(`[Req] error after ${Date.now() - startTime}ms: ${e.message}`)
+          reject(e)
+        })
+        if (payload) req.write(payload)
+        req.end()
+      }
+
+      const handleResponse = (res: http.IncomingMessage) => {
+        this.out.appendLine(`[Req] ${res.statusCode} after ${Date.now() - startTime}ms`)
+        let data = ''
+        res.on('data', (chunk: string) => { data += chunk })
+        res.on('end', () => {
+          if (res.statusCode === 401) {
+            reject({ response: { statusCode: 401 } })
+            return
+          }
+          resolve({ body: data, statusCode: res.statusCode })
+        })
+      }
+
+      if (!proxy) {
+        doRequest()
+        return
+      }
+
+      const proxyUrl = new URL(proxy)
+      const proxyPort = Number(proxyUrl.port) || 80
+      const proxyHost = proxyUrl.hostname
+      this.out.appendLine(`[Req] connecting to proxy ${proxyHost}:${proxyPort}`)
+      const tcpSocket = net.connect(proxyPort, proxyHost, () => {
+        this.out.appendLine(`[Req] proxy TCP connected, sending CONNECT`)
+        tcpSocket.write(`CONNECT ${url.hostname}:443 HTTP/1.1\r\nHost: ${url.hostname}:443\r\nProxy-Connection: keep-alive\r\n\r\n`)
+        let header = ''
+        const onData = (chunk: Buffer) => {
+          header += chunk.toString()
+          if (!header.includes('\r\n\r\n')) return
+          tcpSocket.removeListener('data', onData)
+          this.out.appendLine(`[Req] proxy response: ${header.split('\r\n')[0]}`)
+          if (!header.startsWith('HTTP/1.1 200') && !header.startsWith('HTTP/1.0 200')) {
+            reject(new Error(`Proxy CONNECT failed: ${header.split('\r\n')[0]}`))
+            tcpSocket.destroy()
+            return
+          }
+          const tlsSocket = tls.connect({ socket: tcpSocket, servername: url.hostname }, () => {
+            this.out.appendLine(`[Req] TLS handshake done, sending HTTP request`)
+            doRequest(tlsSocket)
+          })
+          tlsSocket.on('error', (e: any) => {
+            this.out.appendLine(`[Req] TLS error: ${e.message}`)
+            reject(e)
+          })
+        }
+        tcpSocket.on('data', onData)
+      })
+      tcpSocket.setTimeout(10000, () => {
+        tcpSocket.destroy()
+        reject(new Error('Proxy connection timeout'))
+      })
+      tcpSocket.on('error', (e: any) => {
+        this.out.appendLine(`[Req] TCP error connecting to proxy: ${e.code} ${e.message}`)
+        reject(e)
+      })
     })
   }
 
@@ -81,14 +212,18 @@ export class CodeTime {
   }
 
   private init(): void {
+    const proxyUrl = vscode.workspace.getConfiguration('codetime').get<string>('proxy')
+      || process.env.HTTPS_PROXY || process.env.HTTP_PROXY || process.env.https_proxy || process.env.http_proxy
+    this.out.appendLine(`[Init] proxy=${proxyUrl || '(none)'}`)
+    this.out.appendLine(`[Init] serverEntrypoint=${vscode.workspace.getConfiguration('codetime').serverEntrypoint}`)
+    this.out.appendLine(`[Init] token=${this.token ? '***' + this.token.slice(-4) : '(empty)'}`)
+
     this.statusBar.text = `$(clock) ${vscode.l10n.t('CodeTime: Initializing...')}`
     this.statusBar.show()
     this.setupEventListeners()
     this.getCurrentDuration()
     this.inter = setInterval(() => {
       this.getCurrentDuration()
-      // TODO: Upload Local Data
-      // this.uploadLocalData();
     }, 60 * 1000)
   }
 
@@ -219,20 +354,13 @@ export class CodeTime {
             this.statusBar.command = 'codetime.getToken'
             return
           }
-          this.client.post(`${vscode.workspace.getConfiguration('codetime').serverEntrypoint}/v3/users/event-log`, {
-            json: data,
-            headers: {
-              'User-Agent': 'CodeTime Client',
-              'Authorization': `Bearer ${this.token}`,
-            },
-          }).catch((error: any) => {
+          this.apiRequest('POST', '/v3/users/event-log', data).catch((error: any) => {
             if (error.response?.statusCode === 401) {
               this.handleAuthError()
             }
             else {
               this.out.appendLine(`Error: ${error}`)
             }
-            // TODO: Append Data To Local
           })
         }
       }
@@ -281,12 +409,11 @@ export class CodeTime {
     this.statusBar.command = 'codetime.toDashboard'
     this.statusBar.tooltip = vscode.l10n.t('CodeTime: Head to the dashboard for statistics')
     const minutes = getMinutes(key)
-    this.client.get(`${vscode.workspace.getConfiguration('codetime').serverEntrypoint}/v3/users/self/minutes?minutes=${minutes}`, {
-      headers: {
-        'User-Agent': 'CodeTime Client',
-        'Authorization': `Bearer ${this.token}`,
-      },
-    }).then(async (res: any) => {
+    const proxyUrl = vscode.workspace.getConfiguration('codetime').get<string>('proxy')
+      || process.env.HTTPS_PROXY || process.env.HTTP_PROXY || process.env.https_proxy || process.env.http_proxy
+    const serverUrl = vscode.workspace.getConfiguration('codetime').serverEntrypoint
+    this.out.appendLine(`[Duration] GET ${serverUrl}/v3/users/self/minutes?minutes=${minutes} proxy=${proxyUrl || '(none)'}`)
+    this.apiRequest('GET', `/v3/users/self/minutes?minutes=${minutes}`).then(async (res: any) => {
       const data = JSON.parse(res.body)
       const { minutes } = data
       this.out.appendLine(`Current duration: ${minutes} minutes`)
@@ -301,7 +428,8 @@ export class CodeTime {
         this.handleAuthError()
       }
       else {
-        this.out.appendLine(`Network error: ${error.message || error}`)
+        this.out.appendLine(`[Duration] Network error: ${error.message || error}`)
+        if (error.code) this.out.appendLine(`[Duration] Error code: ${error.code}`)
         this.statusBar.text = `$(clock) ${vscode.l10n.t('CodeTime: Network Error')}`
         this.statusBar.tooltip = vscode.l10n.t('CodeTime: Network connection failed')
         this.statusBar.command = 'codetime.toDashboard'

--- a/src/codetime.ts
+++ b/src/codetime.ts
@@ -89,9 +89,10 @@ export class CodeTime {
 
       const finish = (parsed: { statusCode: number, body: string }) => {
         this.out.appendLine(`[Req] ${parsed.statusCode} after ${Date.now() - startTime}ms`)
-        if (parsed.statusCode === 401) {
-          const err = new Error('Unauthorized') as Error & { response: { statusCode: number } }
-          err.response = { statusCode: 401 }
+        if (parsed.statusCode >= 400) {
+          const message = parsed.statusCode === 401 ? 'Unauthorized' : `HTTP ${parsed.statusCode}`
+          const err = new Error(message) as Error & { response: { statusCode: number, body: string } }
+          err.response = { statusCode: parsed.statusCode, body: parsed.body }
           reject(err)
           return
         }
@@ -131,7 +132,16 @@ export class CodeTime {
       }
 
       // With proxy: open TCP/TLS to proxy, then CONNECT (HTTPS target) or absolute-form (HTTP target)
-      const proxyUrlParsed = new URL(proxy)
+      let proxyUrlParsed: URL
+      try {
+        proxyUrlParsed = new URL(proxy)
+      }
+      catch {
+        const error = new Error(`Invalid proxy URL: "${this.redactUrlForLogging(proxy)}". Expected format: http://host:port or https://host:port.`)
+        this.out.appendLine(`[Req] invalid proxy configuration: ${error.message}`)
+        reject(error)
+        return
+      }
       if (proxyUrlParsed.protocol !== 'http:' && proxyUrlParsed.protocol !== 'https:') {
         const error = new Error(`Unsupported proxy protocol: ${proxyUrlParsed.protocol}. Only http: and https: proxies are supported.`)
         this.out.appendLine(`[Req] invalid proxy configuration: ${error.message}`)
@@ -141,6 +151,7 @@ export class CodeTime {
       const isHttpsProxy = proxyUrlParsed.protocol === 'https:'
       const proxyPort = Number(proxyUrlParsed.port) || (isHttpsProxy ? 443 : 80)
       const proxyHost = proxyUrlParsed.hostname
+      const targetAuthority = url.hostname.includes(':') ? `[${url.hostname}]:${targetPort}` : `${url.hostname}:${targetPort}`
 
       const proxyAuthHeader = proxyUrlParsed.username
         ? `Proxy-Authorization: Basic ${Buffer.from(`${decodeURIComponent(proxyUrlParsed.username)}:${decodeURIComponent(proxyUrlParsed.password)}`).toString('base64')}`
@@ -187,6 +198,7 @@ export class CodeTime {
       const onProxyReady = (proxySocket: net.Socket | tls.TLSSocket) => {
         if (!isHttpsTarget) {
           this.out.appendLine(`[Req] proxy connected, sending HTTP request (absolute form)`)
+          proxySocket.setTimeout(0)
           writeRequestAndRead(
             proxySocket,
             `${method} ${url.toString()} HTTP/1.1`,
@@ -197,8 +209,8 @@ export class CodeTime {
 
         this.out.appendLine(`[Req] proxy connected, sending CONNECT`)
         const connectLines = [
-          `CONNECT ${url.hostname}:${targetPort} HTTP/1.1`,
-          `Host: ${url.hostname}:${targetPort}`,
+          `CONNECT ${targetAuthority} HTTP/1.1`,
+          `Host: ${targetAuthority}`,
           ...(proxyAuthHeader ? [proxyAuthHeader] : []),
           'Proxy-Connection: keep-alive',
           '',
@@ -223,6 +235,7 @@ export class CodeTime {
             reject(new Error(`Proxy CONNECT failed: ${statusLine}`))
             return
           }
+          proxySocket.setTimeout(0)
           const residue = connectBuf.slice(idx + 4)
           if (residue.length > 0) {
             proxySocket.unshift(residue)

--- a/src/codetime.ts
+++ b/src/codetime.ts
@@ -132,6 +132,12 @@ export class CodeTime {
 
       // With proxy: open TCP/TLS to proxy, then CONNECT (HTTPS target) or absolute-form (HTTP target)
       const proxyUrlParsed = new URL(proxy)
+      if (proxyUrlParsed.protocol !== 'http:' && proxyUrlParsed.protocol !== 'https:') {
+        const error = new Error(`Unsupported proxy protocol: ${proxyUrlParsed.protocol}. Only http: and https: proxies are supported.`)
+        this.out.appendLine(`[Req] invalid proxy configuration: ${error.message}`)
+        reject(error)
+        return
+      }
       const isHttpsProxy = proxyUrlParsed.protocol === 'https:'
       const proxyPort = Number(proxyUrlParsed.port) || (isHttpsProxy ? 443 : 80)
       const proxyHost = proxyUrlParsed.hostname
@@ -267,8 +273,27 @@ export class CodeTime {
     }
   }
 
+  private redactUrlForLogging(url?: string): string {
+    if (!url) {
+      return '(none)'
+    }
+
+    try {
+      const parsed = new URL(url)
+      parsed.username = ''
+      parsed.password = ''
+      parsed.pathname = ''
+      parsed.search = ''
+      parsed.hash = ''
+      return `${parsed.protocol}//${parsed.host}`
+    }
+    catch {
+      return '(configured)'
+    }
+  }
+
   private init(): void {
-    this.out.appendLine(`[Init] proxy=${this.getProxyUrl() || '(none)'}`)
+    this.out.appendLine(`[Init] proxy=${this.redactUrlForLogging(this.getProxyUrl())}`)
     this.out.appendLine(`[Init] serverEntrypoint=${vscode.workspace.getConfiguration('codetime').serverEntrypoint}`)
     this.out.appendLine(`[Init] token=${this.token ? `***${this.token.slice(-4)}` : '(empty)'}`)
 

--- a/src/codetime.ts
+++ b/src/codetime.ts
@@ -1,8 +1,9 @@
-import * as os from 'node:os'
-import process from 'node:process'
+import { Buffer } from 'node:buffer'
 import http from 'node:http'
 import https from 'node:https'
 import net from 'node:net'
+import * as os from 'node:os'
+import process from 'node:process'
 import tls from 'node:tls'
 
 import osName from 'os-name'
@@ -46,141 +47,196 @@ export class CodeTime {
 
   public disposable!: vscode.Disposable
   state: vscode.Memento
-  private proxyUrl: string = ''
   token: string = ''
   inter!: NodeJS.Timeout
   constructor(state: vscode.Memento, secrets: vscode.SecretStorage) {
     this.state = state
     this.secrets = secrets
     this.initSetToken().then(() => {
-      const configProxy = vscode.workspace.getConfiguration('codetime').get<string>('proxy')
-      this.proxyUrl = configProxy
-        || process.env.HTTPS_PROXY || process.env.HTTP_PROXY
-        || process.env.https_proxy || process.env.http_proxy
-        || ''
       this.init()
     })
   }
 
-  private apiRequest(method: string, path: string, body?: any): Promise<any> {
+  private getProxyUrl(): string {
+    return (
+      vscode.workspace.getConfiguration('codetime').get<string>('proxy')
+      || process.env.HTTPS_PROXY || process.env.HTTP_PROXY
+      || process.env.https_proxy || process.env.http_proxy
+      || ''
+    )
+  }
+
+  private apiRequest(method: string, path: string, body?: any): Promise<{ body: string, statusCode: number }> {
     const serverUrl = vscode.workspace.getConfiguration('codetime').serverEntrypoint as string
     const url = new URL(path, serverUrl)
     const payload = body ? JSON.stringify(body) : undefined
-    const proxy = this.proxyUrl
+    const proxy = this.getProxyUrl()
+    const isHttpsTarget = url.protocol === 'https:'
+    const targetPort = Number(url.port) || (isHttpsTarget ? 443 : 80)
+
+    const baseHeaders: Record<string, string> = {
+      'User-Agent': 'CodeTime Client',
+      'Authorization': `Bearer ${this.token}`,
+    }
+    if (payload) {
+      baseHeaders['Content-Type'] = 'application/json'
+      baseHeaders['Content-Length'] = Buffer.byteLength(payload).toString()
+    }
 
     return new Promise((resolve, reject) => {
       const startTime = Date.now()
       this.out.appendLine(`[Req] ${method} ${path} proxy=${proxy || 'none'}`)
 
-      const doRequest = (tlsSocket?: tls.TLSSocket) => {
-        if (tlsSocket) {
-          const lines = [
-            `${method} ${url.pathname + url.search} HTTP/1.1`,
-            `Host: ${url.hostname}`,
-            `User-Agent: CodeTime Client`,
-            `Authorization: Bearer ${this.token}`,
-            `Connection: close`,
-            ...(payload ? [`Content-Type: application/json`, `Content-Length: ${Buffer.byteLength(payload)}`] : []),
-            ``,
-            payload || ``,
-          ]
-          tlsSocket.write(lines.join('\r\n'))
-          let raw = ''
-          tlsSocket.on('data', (chunk: Buffer) => { raw += chunk.toString() })
-          tlsSocket.on('end', () => {
-            tlsSocket.destroy()
-            const headerEnd = raw.indexOf('\r\n\r\n')
-            const statusLine = raw.split('\r\n')[0]
-            const statusCode = Number(statusLine.split(' ')[1])
-            const body = headerEnd >= 0 ? raw.slice(headerEnd + 4) : ''
-            this.out.appendLine(`[Req] ${statusCode} after ${Date.now() - startTime}ms`)
-            if (statusCode === 401) {
-              reject({ response: { statusCode: 401 } })
-            }
-            else {
-              resolve({ body, statusCode })
-            }
-          })
-          tlsSocket.on('error', (e: any) => {
-            this.out.appendLine(`[Req] socket error: ${e.message}`)
-            reject(e)
-          })
+      const finish = (parsed: { statusCode: number, body: string }) => {
+        this.out.appendLine(`[Req] ${parsed.statusCode} after ${Date.now() - startTime}ms`)
+        if (parsed.statusCode === 401) {
+          const err = new Error('Unauthorized') as Error & { response: { statusCode: number } }
+          err.response = { statusCode: 401 }
+          reject(err)
           return
         }
+        resolve(parsed)
+      }
 
-        const req = https.request({
+      // No proxy: use Node's http(s) client directly
+      if (!proxy) {
+        const lib = isHttpsTarget ? https : http
+        const req = lib.request({
           method,
           hostname: url.hostname,
-          port: 443,
+          port: targetPort,
           path: url.pathname + url.search,
-          timeout: 30000,
-          headers: {
-            'User-Agent': 'CodeTime Client',
-            'Authorization': `Bearer ${this.token}`,
-            ...(payload ? { 'Content-Type': 'application/json', 'Content-Length': Buffer.byteLength(payload).toString() } : {}),
-          },
-        }, handleResponse)
+          timeout: 30_000,
+          headers: baseHeaders,
+        }, (res: http.IncomingMessage) => {
+          const chunks: Buffer[] = []
+          res.on('data', (chunk: Buffer) => chunks.push(chunk))
+          res.on('end', () => {
+            finish({
+              statusCode: res.statusCode ?? 0,
+              body: Buffer.concat(chunks).toString('utf8'),
+            })
+          })
+        })
         req.on('error', (e: any) => {
           this.out.appendLine(`[Req] error after ${Date.now() - startTime}ms: ${e.message}`)
           reject(e)
         })
-        if (payload) req.write(payload)
+        req.on('timeout', () => req.destroy(new Error('request timeout')))
+        if (payload) {
+          req.write(payload)
+        }
         req.end()
-      }
-
-      const handleResponse = (res: http.IncomingMessage) => {
-        this.out.appendLine(`[Req] ${res.statusCode} after ${Date.now() - startTime}ms`)
-        let data = ''
-        res.on('data', (chunk: string) => { data += chunk })
-        res.on('end', () => {
-          if (res.statusCode === 401) {
-            reject({ response: { statusCode: 401 } })
-            return
-          }
-          resolve({ body: data, statusCode: res.statusCode })
-        })
-      }
-
-      if (!proxy) {
-        doRequest()
         return
       }
 
-      const proxyUrl = new URL(proxy)
-      const proxyPort = Number(proxyUrl.port) || 80
-      const proxyHost = proxyUrl.hostname
-      this.out.appendLine(`[Req] connecting to proxy ${proxyHost}:${proxyPort}`)
-      const tcpSocket = net.connect(proxyPort, proxyHost, () => {
-        this.out.appendLine(`[Req] proxy TCP connected, sending CONNECT`)
-        tcpSocket.write(`CONNECT ${url.hostname}:443 HTTP/1.1\r\nHost: ${url.hostname}:443\r\nProxy-Connection: keep-alive\r\n\r\n`)
-        let header = ''
-        const onData = (chunk: Buffer) => {
-          header += chunk.toString()
-          if (!header.includes('\r\n\r\n')) return
-          tcpSocket.removeListener('data', onData)
-          this.out.appendLine(`[Req] proxy response: ${header.split('\r\n')[0]}`)
-          if (!header.startsWith('HTTP/1.1 200') && !header.startsWith('HTTP/1.0 200')) {
-            reject(new Error(`Proxy CONNECT failed: ${header.split('\r\n')[0]}`))
-            tcpSocket.destroy()
+      // With proxy: open TCP/TLS to proxy, then CONNECT (HTTPS target) or absolute-form (HTTP target)
+      const proxyUrlParsed = new URL(proxy)
+      const isHttpsProxy = proxyUrlParsed.protocol === 'https:'
+      const proxyPort = Number(proxyUrlParsed.port) || (isHttpsProxy ? 443 : 80)
+      const proxyHost = proxyUrlParsed.hostname
+
+      const proxyAuthHeader = proxyUrlParsed.username
+        ? `Proxy-Authorization: Basic ${Buffer.from(`${decodeURIComponent(proxyUrlParsed.username)}:${decodeURIComponent(proxyUrlParsed.password)}`).toString('base64')}`
+        : ''
+
+      this.out.appendLine(`[Req] connecting to proxy ${proxyHost}:${proxyPort} (${proxyUrlParsed.protocol})`)
+
+      const writeRequestAndRead = (socket: net.Socket | tls.TLSSocket, requestLine: string, extraHeaders: string[] = []) => {
+        const lines = [
+          requestLine,
+          `Host: ${url.host}`,
+          ...Object.entries(baseHeaders).map(([k, v]) => `${k}: ${v}`),
+          ...extraHeaders,
+          'Connection: close',
+          '',
+          payload || '',
+        ]
+        socket.write(lines.join('\r\n'))
+        const chunks: Buffer[] = []
+        socket.on('data', (chunk: Buffer) => chunks.push(chunk))
+        socket.on('end', () => {
+          socket.destroy()
+          try {
+            finish(parseHttpResponse(Buffer.concat(chunks)))
+          }
+          catch (error: any) {
+            this.out.appendLine(`[Req] parse error: ${error.message}`)
+            reject(error)
+          }
+        })
+        socket.on('error', (e: any) => {
+          this.out.appendLine(`[Req] socket error: ${e.message}`)
+          reject(e)
+        })
+      }
+
+      const onProxyReady = (proxySocket: net.Socket | tls.TLSSocket) => {
+        if (!isHttpsTarget) {
+          this.out.appendLine(`[Req] proxy connected, sending HTTP request (absolute form)`)
+          proxySocket.setTimeout(0)
+          writeRequestAndRead(
+            proxySocket,
+            `${method} ${url.toString()} HTTP/1.1`,
+            proxyAuthHeader ? [proxyAuthHeader] : [],
+          )
+          return
+        }
+
+        this.out.appendLine(`[Req] proxy connected, sending CONNECT`)
+        const connectLines = [
+          `CONNECT ${url.hostname}:${targetPort} HTTP/1.1`,
+          `Host: ${url.hostname}:${targetPort}`,
+          ...(proxyAuthHeader ? [proxyAuthHeader] : []),
+          'Proxy-Connection: keep-alive',
+          '',
+          '',
+        ]
+        proxySocket.write(connectLines.join('\r\n'))
+
+        let connectBuf = Buffer.alloc(0)
+        const onConnectData = (chunk: Buffer) => {
+          connectBuf = Buffer.concat([connectBuf, chunk])
+          const idx = connectBuf.indexOf('\r\n\r\n')
+          if (idx === -1) {
             return
           }
-          const tlsSocket = tls.connect({ socket: tcpSocket, servername: url.hostname }, () => {
+          proxySocket.removeListener('data', onConnectData)
+          const headerStr = connectBuf.slice(0, idx).toString('utf8')
+          const statusLine = headerStr.split('\r\n')[0]
+          this.out.appendLine(`[Req] proxy response: ${statusLine}`)
+          const m = statusLine.match(/^HTTP\/\d\.\d (\d{3})/)
+          if (!m || m[1] !== '200') {
+            proxySocket.destroy()
+            reject(new Error(`Proxy CONNECT failed: ${statusLine}`))
+            return
+          }
+          proxySocket.setTimeout(0)
+          const residue = connectBuf.slice(idx + 4)
+          if (residue.length > 0) {
+            proxySocket.unshift(residue)
+          }
+          const tlsSocket = tls.connect({ socket: proxySocket, servername: url.hostname }, () => {
             this.out.appendLine(`[Req] TLS handshake done, sending HTTP request`)
-            doRequest(tlsSocket)
+            writeRequestAndRead(tlsSocket, `${method} ${url.pathname + url.search} HTTP/1.1`)
           })
           tlsSocket.on('error', (e: any) => {
             this.out.appendLine(`[Req] TLS error: ${e.message}`)
             reject(e)
           })
         }
-        tcpSocket.on('data', onData)
-      })
-      tcpSocket.setTimeout(10000, () => {
-        tcpSocket.destroy()
+        proxySocket.on('data', onConnectData)
+      }
+
+      const proxySocket: net.Socket | tls.TLSSocket = isHttpsProxy
+        ? tls.connect({ host: proxyHost, port: proxyPort, servername: proxyHost }, () => onProxyReady(proxySocket))
+        : net.connect(proxyPort, proxyHost, () => onProxyReady(proxySocket))
+      proxySocket.setTimeout(10_000, () => {
+        proxySocket.destroy()
         reject(new Error('Proxy connection timeout'))
       })
-      tcpSocket.on('error', (e: any) => {
-        this.out.appendLine(`[Req] TCP error connecting to proxy: ${e.code} ${e.message}`)
+      proxySocket.on('error', (e: any) => {
+        this.out.appendLine(`[Req] proxy socket error: ${e.code || ''} ${e.message}`)
         reject(e)
       })
     })
@@ -212,11 +268,9 @@ export class CodeTime {
   }
 
   private init(): void {
-    const proxyUrl = vscode.workspace.getConfiguration('codetime').get<string>('proxy')
-      || process.env.HTTPS_PROXY || process.env.HTTP_PROXY || process.env.https_proxy || process.env.http_proxy
-    this.out.appendLine(`[Init] proxy=${proxyUrl || '(none)'}`)
+    this.out.appendLine(`[Init] proxy=${this.getProxyUrl() || '(none)'}`)
     this.out.appendLine(`[Init] serverEntrypoint=${vscode.workspace.getConfiguration('codetime').serverEntrypoint}`)
-    this.out.appendLine(`[Init] token=${this.token ? '***' + this.token.slice(-4) : '(empty)'}`)
+    this.out.appendLine(`[Init] token=${this.token ? `***${this.token.slice(-4)}` : '(empty)'}`)
 
     this.statusBar.text = `$(clock) ${vscode.l10n.t('CodeTime: Initializing...')}`
     this.statusBar.show()
@@ -409,10 +463,6 @@ export class CodeTime {
     this.statusBar.command = 'codetime.toDashboard'
     this.statusBar.tooltip = vscode.l10n.t('CodeTime: Head to the dashboard for statistics')
     const minutes = getMinutes(key)
-    const proxyUrl = vscode.workspace.getConfiguration('codetime').get<string>('proxy')
-      || process.env.HTTPS_PROXY || process.env.HTTP_PROXY || process.env.https_proxy || process.env.http_proxy
-    const serverUrl = vscode.workspace.getConfiguration('codetime').serverEntrypoint
-    this.out.appendLine(`[Duration] GET ${serverUrl}/v3/users/self/minutes?minutes=${minutes} proxy=${proxyUrl || '(none)'}`)
     this.apiRequest('GET', `/v3/users/self/minutes?minutes=${minutes}`).then(async (res: any) => {
       const data = JSON.parse(res.body)
       const { minutes } = data
@@ -429,7 +479,9 @@ export class CodeTime {
       }
       else {
         this.out.appendLine(`[Duration] Network error: ${error.message || error}`)
-        if (error.code) this.out.appendLine(`[Duration] Error code: ${error.code}`)
+        if (error.code) {
+          this.out.appendLine(`[Duration] Error code: ${error.code}`)
+        }
         this.statusBar.text = `$(clock) ${vscode.l10n.t('CodeTime: Network Error')}`
         this.statusBar.tooltip = vscode.l10n.t('CodeTime: Network connection failed')
         this.statusBar.command = 'codetime.toDashboard'
@@ -474,6 +526,55 @@ export class CodeTime {
     this.disposable.dispose()
     clearInterval(this.inter)
   }
+}
+
+function parseHttpResponse(buf: Buffer): { statusCode: number, body: string } {
+  const headerEnd = buf.indexOf('\r\n\r\n')
+  if (headerEnd === -1) {
+    throw new Error('Incomplete HTTP response (no header terminator)')
+  }
+  const headerText = buf.slice(0, headerEnd).toString('utf8')
+  const lines = headerText.split('\r\n')
+  const statusLine = lines[0] || ''
+  const m = statusLine.match(/^HTTP\/\d\.\d (\d{3})/)
+  if (!m) {
+    throw new Error(`Invalid status line: ${statusLine}`)
+  }
+  const statusCode = Number(m[1])
+  const headers = new Map<string, string>()
+  for (let i = 1; i < lines.length; i++) {
+    const idx = lines[i].indexOf(':')
+    if (idx > 0) {
+      headers.set(lines[i].slice(0, idx).trim().toLowerCase(), lines[i].slice(idx + 1).trim())
+    }
+  }
+  const rawBody = buf.slice(headerEnd + 4)
+  const isChunked = (headers.get('transfer-encoding') || '').toLowerCase().includes('chunked')
+  const bodyBuf = isChunked ? decodeChunked(rawBody) : rawBody
+  return { statusCode, body: bodyBuf.toString('utf8') }
+}
+
+function decodeChunked(buf: Buffer): Buffer {
+  const out: Buffer[] = []
+  let offset = 0
+  while (offset < buf.length) {
+    const sizeLineEnd = buf.indexOf('\r\n', offset)
+    if (sizeLineEnd === -1) {
+      break
+    }
+    const sizeHex = buf.slice(offset, sizeLineEnd).toString('utf8').split(';')[0].trim()
+    const size = Number.parseInt(sizeHex, 16)
+    if (Number.isNaN(size)) {
+      throw new TypeError(`Invalid chunk size: ${sizeHex}`)
+    }
+    if (size === 0) {
+      break
+    }
+    const dataStart = sizeLineEnd + 2
+    out.push(buf.slice(dataStart, dataStart + size))
+    offset = dataStart + size + 2
+  }
+  return Buffer.concat(out)
 }
 
 function getMinutes(key: string) {


### PR DESCRIPTION
## Summary                                                                                                                                                                                     
                                          
Add HTTP/HTTPS proxy support for users who need to access the CodeTime API through a proxy server (e.g. in corporate networks or remote development environments).                                         
## Changes                                                                                                                                                                                       
                                                                                                                                                                                               
- Added `codetime.proxy` configuration option to set a proxy URL (e.g. `http://127.0.0.1:8080`)                                                                                                  
- Implemented manual HTTP CONNECT tunnel over raw TCP + TLS to ensure the proxy works correctly in VSCode's Extension Host environment (where Node.js `http.Agent` is intercepted by VSCode's    proxy handling)                            
- Replaced `got` HTTP client with Node.js built-in `https`/`net`/`tls` modules to avoid conflicts with `got` v14's `http2-wrapper` which interfered with proxy agent injection                   
- Proxy priority: `codetime.proxy` setting → `HTTPS_PROXY` → `HTTP_PROXY` → `https_proxy` → `http_proxy` environment variables                                                                 
                                                                                                                                                                                                 
## Why manual CONNECT tunnel?                                                                                                                                                                    
                                                                                                                                                                                                 
VSCode Extension Host intercepts `http.Agent`, causing custom proxy agents (e.g. `https-proxy-agent`) to be silently ignored — the request would fall through and connect directly to the target 
IP instead of going through the proxy. The only reliable solution is to manually establish the TCP connection to the proxy, send a `CONNECT` request, upgrade to TLS, then write raw HTTP over   
the established socket.                                                                                                                                                                          
                                                                                                                                                                                                 
## Testing                                                                                                                                                                                     
                                                                                                                                                                                                 
Verified working in a VSCode Remote SSH environment where direct internet access is blocked and only an HTTP proxy is available.

## PS

*This PR was implemented with the assistance of [Claude](https://claude.ai).* And I test it, it works fine.
```
[Init] proxy=http://10.74.176.8:11080
[Init] serverEntrypoint=https://api.codetime.dev
[Init] token=***9c7b
[Duration] GET https://api.codetime.dev/v3/users/self/minutes?minutes=52560000 proxy=http://10.74.176.8:11080
[Req] GET /v3/users/self/minutes?minutes=52560000 proxy=http://10.74.176.8:11080
[Req] connecting to proxy 10.74.176.8:11080
[Req] proxy TCP connected, sending CONNECT
[Req] proxy response: HTTP/1.1 200 Connection Established
[Req] TLS handshake done, sending HTTP request
[Req] 200 after 289ms
Current duration: 191019 minutes
3183 hours 39 minutes
```